### PR TITLE
Added OVERLAPPING pragma to FromField instance

### DIFF
--- a/src/Music/Parts/Internal/Data.hs
+++ b/src/Music/Parts/Internal/Data.hs
@@ -163,7 +163,7 @@ instance FromField [Int] where
 instance FromField Pitch where
   parseField v = mcatMaybes $ fmap pitchFromSPN $ parseField v
 
-instance FromField (Maybe (Ambitus Pitch)) where
+instance {-# OVERLAPPING #-} FromField (Maybe (Ambitus Pitch)) where
   parseField v = fmap (listToAmbitus . mcatMaybes . map pitchFromSPN) $ fmap (splitBy '-') $ parseField v
     where
       listToAmbitus [a,b] = Just $ (a,b)^.ambitus


### PR DESCRIPTION
This fixes the instances overlap caused by:

```
instance FromField a => FromField (Maybe a)
```

imported from Data.Cvs
